### PR TITLE
Add mobile profile header with photo, roles, degrees, and links

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -38,6 +38,21 @@ aliases:
 
 <div id="content" class="content-column">
 
+<div class="mobile-profile">
+<img src="images/profile.png" class="mobile-profile-image" alt="Harry Coppock">
+<h1 class="mobile-profile-name">Harry Coppock</h1>
+<p class="mobile-profile-subtitle">10 Downing Street Fellow &middot; Research Scientist &middot; Visiting Lecturer</p>
+<p class="mobile-profile-degrees">HEA Fellow, PhD, PGCert, MSc, MEng</p>
+<div class="mobile-profile-socials">
+<a href="https://github.com/hcoppockno10" target="_blank" rel="noopener" title="GitHub"><i class="bi bi-github"></i></a>
+<a href="https://www.linkedin.com/in/harry-coppock/" target="_blank" rel="noopener" title="LinkedIn"><i class="bi bi-linkedin"></i></a>
+<a href="https://scholar.google.com/citations?user=sOdVlYoAAAAJ&hl=en" target="_blank" rel="noopener" title="Google Scholar"><i class="bi bi-mortarboard-fill"></i></a>
+<a href="files/CV_HC.pdf" target="_blank" rel="noopener" title="CV" class="sidebar-cv-link">CV</a>
+<span class="mobile-profile-email"><i class="bi bi-envelope"></i> harrygcoppock [at] gmail [dot] com</span>
+</div>
+<a href="https://calendar.app.google/FdE94HZm6inSqstD7" target="_blank" rel="noopener" class="book-meeting-btn"><i class="bi bi-calendar-check"></i> Let's chat!</a>
+</div>
+
 ::: {#about .content-section}
 
 <div style="margin-top: 1.5rem;"></div>

--- a/styles.css
+++ b/styles.css
@@ -452,8 +452,81 @@ details pre {
   margin-bottom: 0.5rem;
 }
 
+/* ===== Mobile Profile Header ===== */
+.mobile-profile {
+  display: none;
+}
+
 /* ===== Responsive ===== */
 @media (max-width: 768px) {
+  .mobile-profile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .mobile-profile-image {
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    margin-bottom: 1rem;
+  }
+
+  .mobile-profile-name {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--color-accent);
+    margin: 0 0 0.4rem;
+  }
+
+  .mobile-profile-subtitle {
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    margin: 0 0 0.3rem;
+  }
+
+  .mobile-profile-degrees {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin: 0 0 0.8rem;
+  }
+
+  .mobile-profile-socials {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    font-size: 1.2rem;
+    margin-bottom: 0.8rem;
+  }
+
+  .mobile-profile-socials a {
+    color: var(--color-accent);
+    transition: color 0.2s;
+  }
+
+  .mobile-profile-socials a:hover {
+    color: var(--color-accent-light);
+  }
+
+  .mobile-profile-email {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    margin-top: 0.3rem;
+    width: 100%;
+  }
+
+  .mobile-profile .book-meeting-btn {
+    display: inline-flex;
+  }
   .main-layout {
     display: block;
     padding: 1.5rem 1rem 5rem;


### PR DESCRIPTION
On mobile viewports, the sidebar profile info was hidden. This adds a dedicated mobile profile section at the top of the content area so visitors on phones see the profile picture, roles, degrees, social links, and contact info before scrolling to the overview.